### PR TITLE
Fix mb_stripos offset parameter for php 8.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           composer update
           php ./vendor/bin/robo prepare:dependencies
-          composer update
+          composer update --prefer-source
           php ./vendor/bin/robo prepare:tests
           php ./vendor/bin/robo prepare:test-autoloading
           composer dump-autoload

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -13,7 +13,7 @@ class RoboFile extends \Robo\Tasks
 
         $config['name'] = 'codeception/phpunit-wrapper-test';
         $config['require-dev']['codeception/codeception'] = getenv('CODECEPTION_VERSION');
-        $config['require-dev']['codeception/module-asserts'] = 'dev-master';
+        $config['require-dev']['codeception/module-asserts'] = '*';
         $config['require-dev']['codeception/module-cli'] = '*';
         $config['require-dev']['codeception/module-db'] = '*';
         $config['require-dev']['codeception/module-filesystem'] = '*';

--- a/src/Constraint/Page.php
+++ b/src/Constraint/Page.php
@@ -25,7 +25,7 @@ class Page extends \PHPUnit\Framework\Constraint\Constraint
     protected function matches($other) : bool
     {
         $other = $this->normalizeText($other);
-        return mb_stripos($other, $this->string, null, 'UTF-8') !== false;
+        return mb_stripos($other, $this->string, 0, 'UTF-8') !== false;
     }
 
     /**


### PR DESCRIPTION
without this the method throws deprecation warning

`mb_stripos(): Passing null to parameter #3 ($offset) of type int is deprecated`